### PR TITLE
DESK-8096 - All Hubs > Upgrade SOAP API authentication

### DIFF
--- a/lib/salesforce_bulk.rb
+++ b/lib/salesforce_bulk.rb
@@ -9,7 +9,7 @@ module SalesforceBulk
   # Your code goes here...
   class Api
 
-    @@SALESFORCE_API_VERSION = '24.0'
+    @@SALESFORCE_API_VERSION = '41.0'
 
     def initialize(username, password, in_sandbox=false)
       @connection = SalesforceBulk::Connection.new(username, password, @@SALESFORCE_API_VERSION, in_sandbox)


### PR DESCRIPTION
[DESK-8096](https://jira.internal.influitive.com/browse/DESK-8096)

SOAP authentication versions is v24., this PR upgrade to v41.